### PR TITLE
remove running of examples to decrease check time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Spatial Overlay for Omic Data from Nanostring GeoMx Data
 Description: Tools for NanoString Technologies GeoMx Technology. Package to 
               easily graph on top of an OME-TIFF image. Plotting annotations 
               can range from tissue segment to gene expression.
-Version: 0.99.14
+Version: 0.99.15
 Encoding: UTF-8
 Authors@R: c(person("Maddy", "Griswold", email = "mgriswold@nanostring.com", role = c("cre","aut")),
              person("Megan", "Vandenberg", email = "mvandenberg@nanostring.com", role = c("ctb")),
@@ -41,5 +41,5 @@ biocViews: GeneExpression, Transcription, CellBasedAssays, DataImport,
            DataRepresentation, Visualization
 VignetteEngine: knitr::rmarkdown
 VignetteBuilder: knitr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Config/testthat/edition: 3

--- a/R/addImage.R
+++ b/R/addImage.R
@@ -11,7 +11,7 @@
 #' @return SpatialOverlay object with image
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
@@ -20,7 +20,7 @@
 #' muBrain <- addImageOmeTiff(overlay = muBrain, 
 #'                            ometiff = image, res = 8)
 #' showImage(muBrain)
-#' 
+#' }
 #' @export
 addImageOmeTiff <- function(overlay, ometiff = NULL, res = NULL, ...){
     if(!is(overlay,"SpatialOverlay")){
@@ -98,7 +98,7 @@ addImageFile <- function(overlay, imageFile = NULL, res = NULL){
 #' @return SpatialOverlay object with image
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
@@ -108,7 +108,7 @@ addImageFile <- function(overlay, imageFile = NULL, res = NULL){
 #'                             ometiff = image, res = 8)
 #'
 #' dim(EBImage::imageData(showImage(muBrain)))
-#' 
+#' }
 #' @export
 add4ChannelImage <- function(overlay, ometiff = NULL, res = NULL, ...){
     if(!is(overlay,"SpatialOverlay")){

--- a/R/addPlottingFactor.R
+++ b/R/addPlottingFactor.R
@@ -14,7 +14,7 @@
 #' @return \code{\link{SpatialOverlay}} object with new plotting factor
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #'
@@ -40,7 +40,7 @@
 #'                              plottingFactor = "ROINum")
 #' 
 #' head(plotFactors(muBrain))
-#' 
+#' }
 #' @export 
 #' 
 setGeneric("addPlottingFactor", signature = "annots",
@@ -364,7 +364,7 @@ setMethod("addPlottingFactor",  "numeric",
 #' @param plottingFactor  name of the new plotting factor
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #'
@@ -373,7 +373,7 @@ setMethod("addPlottingFactor",  "numeric",
 #'                              plottingFactor = "ROINum")
 #' 
 #' head(plotFactors(muBrain))
-#' 
+#' }
 #' @export
 #' @rdname addPlottingFactor 
 #' 

--- a/R/coordinateGeneration.R
+++ b/R/coordinateGeneration.R
@@ -10,14 +10,14 @@ DIRECTIONS <- c("left", "right", "up", "down")
 #' @return df of coordinates for every AOI in the scan
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
 #' muBrain <- createCoordFile(muBrain, outline = FALSE)
 #' 
 #' head(coords(muBrain))
-#' 
+#' }
 #' @importFrom dplyr bind_rows
 #' @importFrom pbapply pbapply 
 #' 
@@ -78,7 +78,7 @@ createCoordFile <- function(overlay, outline = TRUE){
 #' @return binary mask image 
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
@@ -89,7 +89,7 @@ createCoordFile <- function(overlay, outline = TRUE){
 #'                       outline = TRUE)
 #' 
 #' pheatmap::pheatmap(ROIMask, cluster_rows = FALSE, cluster_cols = FALSE)
-#' 
+#' }
 #' @export 
 #' 
 createMask <- function(b64string, metadata, outline = TRUE){
@@ -275,12 +275,12 @@ scaleCoords <- function(overlay){
 #' @return SpatialOverlay object 
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' head(coords(muBrain), 3)
 #' head(coords(moveCoords(muBrain, direction = "up")), 3)                                    
-#' 
+#' }
 #' @export
 moveCoords <- function(overlay, direction = "right"){
     if(!is(overlay,"SpatialOverlay")){

--- a/R/imageManipulation.R
+++ b/R/imageManipulation.R
@@ -58,7 +58,7 @@ imageColoring <- function(omeImage, scanMeta){
 #' @return SpatialOverlay object with updated fluor data
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
@@ -75,7 +75,7 @@ imageColoring <- function(omeImage, scanMeta){
 #'                                dye = "Alexa 488")
 #' 
 #' fluor(muBrain)
-#' 
+#' }
 #' @importFrom plotrix color.id
 #' @importFrom stringr str_to_title
 #' 
@@ -118,6 +118,7 @@ changeImageColoring <- function(overlay, color, dye){
 #' @return SpatialOverlay object with updated fluor data
 #' 
 #' @examples
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
@@ -134,7 +135,7 @@ changeImageColoring <- function(overlay, color, dye){
 #'                                    dye = "Cy5")
 #' 
 #' fluor(muBrain)
-#' 
+#' }
 #' @export
 #'
 changeColoringIntensity <- function(overlay, minInten = NULL,
@@ -191,7 +192,7 @@ changeColoringIntensity <- function(overlay, minInten = NULL,
 #' @return SpatialOverlay object with RGB image
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #'
@@ -203,7 +204,7 @@ changeColoringIntensity <- function(overlay, minInten = NULL,
 #' muBrain <- changeImageColoring(overlay = muBrain, color = "magenta", 
 #'                                dye = "Cy5")
 #' showImage(recolor(muBrain))
-#' 
+#' }
 #' @export
 #'
 recolor <- function(overlay){
@@ -232,7 +233,7 @@ recolor <- function(overlay){
 #' @return SpatialOverlay object with y axis flipped
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
@@ -242,7 +243,7 @@ recolor <- function(overlay){
 #'                            ometiff = image, res = 8)
 #' 
 #' showImage(flipY(muBrain))
-#' 
+#' }
 #' @importFrom magick image_flip
 #' 
 #' @export 
@@ -272,7 +273,7 @@ flipY <- function(overlay){
 #' @return SpatialOverlay object with x axis flipped
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
@@ -282,7 +283,7 @@ flipY <- function(overlay){
 #'                            ometiff = image, res = 8)
 #' 
 #' showImage(flipX(muBrain))
-#' 
+#' }
 #' @importFrom magick image_flop
 #' 
 #' @export 
@@ -387,7 +388,7 @@ crop <- function(overlay, xmin, xmax, ymin, ymax, coords = TRUE){
 #' @return SpatialOverlay object
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
@@ -404,7 +405,7 @@ crop <- function(overlay, xmin, xmax, ymin, ymax, coords = TRUE){
 #' 
 #' plotSpatialOverlay(overlay = muBrainCrop, scaleBar = FALSE,
 #'                    hiRes = TRUE, legend = FALSE)
-#' 
+#' }
 #' @importFrom magick image_info
 #' 
 #' @export 
@@ -482,6 +483,7 @@ cropSamples <- function(overlay, sampleIDs, buffer = 0.1, sampsOnly = TRUE){
 #' @return SpatialOverlay object 
 #' 
 #' @examples
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
@@ -494,7 +496,7 @@ cropSamples <- function(overlay, sampleIDs, buffer = 0.1, sampsOnly = TRUE){
 #' 
 #' plotSpatialOverlay(overlay = muBrainCrop, legend = FALSE, 
 #'                    hiRes = FALSE, scaleBar = FALSE)
-#'                    
+#' }              
 #' @importFrom EBImage imageData
 #' @importFrom magick as_EBImage
 #' @importFrom magick image_read

--- a/R/omeExtraction.R
+++ b/R/omeExtraction.R
@@ -8,10 +8,10 @@
 #' @return list of xml data
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' image <- downloadMouseBrainImage()
 #' xml <- xmlExtraction(ometiff = image)
-#' 
+#' }
 #' @importFrom XML xmlInternalTreeParse
 #' @importFrom XML xmlToList
 #' @importFrom RBioFormats read.omexml
@@ -163,10 +163,10 @@ imageExtraction <- function(ometiff, res = 6, scanMeta = NULL, saveFile = FALSE,
 #' @importFrom RBioFormats read.metadata
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' image <- downloadMouseBrainImage()
 #' checkValidRes(ometiff = image)
-#' 
+#' }
 #' @export
 #' 
 checkValidRes <- function(ometiff){

--- a/R/plottingBasics.R
+++ b/R/plottingBasics.R
@@ -27,13 +27,13 @@
 #' @return gp 
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip",
 #'                                     package = "SpatialOmicsOverlay")))
 #'                              
 #' plotSpatialOverlay(overlay = muBrain, legend = FALSE,  
 #'                    hiRes = FALSE, scaleBar = FALSE)
-#' 
+#' }
 #' @importFrom scattermore geom_scattermore
 #' @import ggplot2
 #' @importFrom magick image_ggplot
@@ -410,7 +410,7 @@ scaleBarPrinting <- function(gp, scaleBar, corner = "bottomright",
 #' @import ggplot2
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip",
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
@@ -427,7 +427,7 @@ scaleBarPrinting <- function(gp, scaleBar, corner = "bottomright",
 #' cowplot::ggdraw() + 
 #'     cowplot::draw_plot(gp) +
 #'     cowplot::draw_plot(legend, scale = 0.12, x = -0.3, y = -0.25)
-#' 
+#' }
 #' @export
 #' 
 fluorLegend <- function(overlay, nrow = 4, textSize = 10, 

--- a/R/readSpatialOverlay.R
+++ b/R/readSpatialOverlay.R
@@ -23,7 +23,7 @@
 #' @return \code{\linkS4class{SpatialOverlay}} of slide
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain_GxT <- readRDS(unzip(system.file("extdata", "muBrain_GxT.zip", 
 #'                          package = "SpatialOmicsOverlay")))
 #' 
@@ -32,7 +32,7 @@
 #' muBrain <- readSpatialOverlay(ometiff = image, annots = muBrain_GxT[,1:5], 
 #'                               slideName = "4", image = TRUE, res = 8, 
 #'                               saveFile = FALSE, outline = FALSE)
-#' 
+#' }
 #' @importFrom readxl read_xlsx
 #' @importFrom data.table fread
 #' @importFrom GeomxTools sData

--- a/R/removeSamples.R
+++ b/R/removeSamples.R
@@ -6,7 +6,7 @@
 #' @return SpatialOverlay object without samples in remove
 #' 
 #' @examples
-#' 
+#' \dontrun{
 #' muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
 #'                                     package = "SpatialOmicsOverlay")))
 #' 
@@ -21,7 +21,7 @@
 #' 
 #' muBrain
 #' muBrainSub
-#' 
+#' }
 #' @export 
 #' 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,10 +14,10 @@ IMAGEFILE <- "image_files/mu_brain_004.ome.tiff"
 #' @return reformatted string
 #' 
 #' @examples 
-#' 
+#' \dontrun{
 #' start_string <- stringi::stri_rand_strings(n = 1, length = 250)
 #' bookendStr(start_string, bookend = 6)
-#' 
+#' }
 #' @export
 bookendStr <- function(x, bookend = 8){
     if(!is(x,"character")){
@@ -40,11 +40,12 @@ bookendStr <- function(x, bookend = 8){
 #' @return df of ROI annotations
 #' 
 #' @examples 
+#' \dontrun{
 #' muBrainLW <- system.file("extdata", "muBrain_LabWorksheet.txt", 
 #'                          package = "SpatialOmicsOverlay")
 #' 
 #' muBrainLW <- readLabWorksheet(muBrainLW, slideName = "4")
-#' 
+#' }
 #' @export
 readLabWorksheet <- function(lw, slideName){
     if(!file.exists(lw)){
@@ -79,9 +80,9 @@ readLabWorksheet <- function(lw, slideName){
 #' @importFrom BiocFileCache bfccache
 #' 
 #' @examples 
-#' 
+#' \dontrun{
 #' image <- downloadMouseBrainImage()
-#'
+#' }
 #' @export
 downloadMouseBrainImage <- function(){
     fileURL <- paste(URL, IMAGES, sep = "/")
@@ -115,10 +116,6 @@ downloadMouseBrainImage <- function(){
 #' 
 #' @return BioFileCache
 #' 
-#' @examples 
-#' 
-#' bfc <- .get_cache()
-#'
 #' @noRd
 #' 
 .get_cache <- function(){

--- a/R/xmlParsing.R
+++ b/R/xmlParsing.R
@@ -18,13 +18,13 @@ COLORS <- c(Blue  = "#0000feff",
 #' @importFrom XML xmlToList
 #' 
 #' @examples 
-#' 
+#' \dontrun{
 #' image <- downloadMouseBrainImage()
 #' 
 #' xml <- xmlExtraction(ometiff = image)
 #' 
 #' scan_metadata <- parseScanMetadata(omexml = xml)
-#' 
+#' }
 #' @export
 #' 
 
@@ -60,6 +60,7 @@ parseScanMetadata <- function(omexml){
 #' @importFrom XML xmlToList
 #' 
 #' @examples 
+#' \dontrun{
 #' image <- downloadMouseBrainImage()
 #' 
 #' xml <- xmlExtraction(ometiff = image)
@@ -72,7 +73,7 @@ parseScanMetadata <- function(omexml){
 #' overlay <- parseOverlayAttrs(omexml = xml, 
 #'                              annots = muBrainLW, 
 #'                              labworksheet = TRUE)
-#' 
+#' }
 #' @export
 #' 
 

--- a/man/add4ChannelImage.Rd
+++ b/man/add4ChannelImage.Rd
@@ -27,7 +27,7 @@ Add 4-channel image to SpatialOverlay from OME-TIFF. Allows for recoloring
 of image
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -37,5 +37,5 @@ muBrain <- add4ChannelImage(overlay = muBrain,
                             ometiff = image, res = 8)
 
 dim(EBImage::imageData(showImage(muBrain)))
-
+}
 }

--- a/man/addImageOmeTiff.Rd
+++ b/man/addImageOmeTiff.Rd
@@ -25,7 +25,7 @@ SpatialOverlay object with image
 Add image to SpatialOverlay from OME-TIFF
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -34,5 +34,5 @@ image <- downloadMouseBrainImage()
 muBrain <- addImageOmeTiff(overlay = muBrain, 
                            ometiff = image, res = 8)
 showImage(muBrain)
-
+}
 }

--- a/man/addPlottingFactor.Rd
+++ b/man/addPlottingFactor.Rd
@@ -45,7 +45,7 @@ counts from}
 Add plotting factor to \code{\link{SpatialOverlay}} object
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -71,8 +71,8 @@ muBrain <- addPlottingFactor(overlay = muBrain,
                              plottingFactor = "ROINum")
 
 head(plotFactors(muBrain))
-
-
+}
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -81,5 +81,5 @@ muBrain <- addPlottingFactor(overlay = muBrain,
                              plottingFactor = "ROINum")
 
 head(plotFactors(muBrain))
-
+}
 }

--- a/man/bookendStr.Rd
+++ b/man/bookendStr.Rd
@@ -19,8 +19,8 @@ Print first and last n characters of string in this format:
 "### ... ### (x total char)"
 }
 \examples{
-
+\dontrun{
 start_string <- stringi::stri_rand_strings(n = 1, length = 250)
 bookendStr(start_string, bookend = 6)
-
+}
 }

--- a/man/changeColoringIntensity.Rd
+++ b/man/changeColoringIntensity.Rd
@@ -23,6 +23,7 @@ SpatialOverlay object with updated fluor data
 Update color intensities for changing to RGB image
 }
 \examples{
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -39,5 +40,5 @@ muBrain <- changeColoringIntensity(overlay = muBrain,
                                    dye = "Cy5")
 
 fluor(muBrain)
-
+}
 }

--- a/man/changeImageColoring.Rd
+++ b/man/changeImageColoring.Rd
@@ -21,7 +21,7 @@ SpatialOverlay object with updated fluor data
 Update color scheme for changing to RGB image
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -38,5 +38,5 @@ muBrain <- changeImageColoring(overlay = muBrain, color = "#42f5ef",
                                dye = "Alexa 488")
 
 fluor(muBrain)
-
+}
 }

--- a/man/checkValidRes.Rd
+++ b/man/checkValidRes.Rd
@@ -16,8 +16,8 @@ value of lowest res image
 Determine lowest resolution image in OME-TIFF
 }
 \examples{
-
+\dontrun{
 image <- downloadMouseBrainImage()
 checkValidRes(ometiff = image)
-
+}
 }

--- a/man/createCoordFile.Rd
+++ b/man/createCoordFile.Rd
@@ -19,12 +19,12 @@ df of coordinates for every AOI in the scan
 Create coordinate file for entire scan
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
 muBrain <- createCoordFile(muBrain, outline = FALSE)
 
 head(coords(muBrain))
-
+}
 }

--- a/man/createMask.Rd
+++ b/man/createMask.Rd
@@ -20,7 +20,7 @@ binary mask image
 Create a binary mask from a base 64 string
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -31,5 +31,5 @@ ROIMask <- createMask(b64string = position(overlay(muBrain))[samp],
                       outline = TRUE)
 
 pheatmap::pheatmap(ROIMask, cluster_rows = FALSE, cluster_cols = FALSE)
-
+}
 }

--- a/man/cropSamples.Rd
+++ b/man/cropSamples.Rd
@@ -22,7 +22,7 @@ SpatialOverlay object
 Crop to zoom in on given ROIs
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -39,5 +39,5 @@ muBrainCrop <- suppressWarnings(cropSamples(overlay = muBrain,
 
 plotSpatialOverlay(overlay = muBrainCrop, scaleBar = FALSE,
                    hiRes = TRUE, legend = FALSE)
-
+}
 }

--- a/man/cropTissue.Rd
+++ b/man/cropTissue.Rd
@@ -18,6 +18,7 @@ SpatialOverlay object
 Crop to remove black boundary around tissue.
 }
 \examples{
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -30,5 +31,5 @@ muBrainCrop <- cropTissue(overlay = muBrain)
 
 plotSpatialOverlay(overlay = muBrainCrop, legend = FALSE, 
                    hiRes = FALSE, scaleBar = FALSE)
-                   
+}              
 }

--- a/man/downloadMouseBrainImage.Rd
+++ b/man/downloadMouseBrainImage.Rd
@@ -16,7 +16,7 @@ Download Mouse Brain OME-TIFF from NanoString's Spatial Organ Atlas
 https://nanostring.com/products/geomx-digital-spatial-profiler/spatial-organ-atlas/mouse-brain/
 }
 \examples{
-
+\dontrun{
 image <- downloadMouseBrainImage()
-
+}
 }

--- a/man/flipX.Rd
+++ b/man/flipX.Rd
@@ -16,7 +16,7 @@ SpatialOverlay object with x axis flipped
 Flip x axis in image and overlay points
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -26,5 +26,5 @@ muBrain <- addImageOmeTiff(overlay = muBrain,
                            ometiff = image, res = 8)
 
 showImage(flipX(muBrain))
-
+}
 }

--- a/man/flipY.Rd
+++ b/man/flipY.Rd
@@ -16,7 +16,7 @@ SpatialOverlay object with y axis flipped
 Flip y axis in image and overlay points
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -26,5 +26,5 @@ muBrain <- addImageOmeTiff(overlay = muBrain,
                            ometiff = image, res = 8)
 
 showImage(flipY(muBrain))
-
+}
 }

--- a/man/fluorLegend.Rd
+++ b/man/fluorLegend.Rd
@@ -26,7 +26,7 @@ gp of fluorescence legend
 Creates legend that can be overlayed on image using \code{cowplot}.
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip",
                                     package = "SpatialOmicsOverlay")))
 
@@ -43,5 +43,5 @@ legend <- fluorLegend(muBrain, nrow = 2, textSize = 3, boxColor = "red")
 cowplot::ggdraw() + 
     cowplot::draw_plot(gp) +
     cowplot::draw_plot(legend, scale = 0.12, x = -0.3, y = -0.25)
-
+}
 }

--- a/man/moveCoords.Rd
+++ b/man/moveCoords.Rd
@@ -19,10 +19,10 @@ If generated coordinates do not match the image use this
 function to move coordinates. Coordinates are only changed 1 pixel at a time.
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 head(coords(muBrain), 3)
 head(coords(moveCoords(muBrain, direction = "up")), 3)                                    
-
+}
 }

--- a/man/parseOverlayAttrs.Rd
+++ b/man/parseOverlayAttrs.Rd
@@ -21,6 +21,7 @@ SpatialPosition of AOIs containing metadata and base64encoded positions
 Parse the xml file for AOI attributes in GeoMx images
 }
 \examples{
+\dontrun{
 image <- downloadMouseBrainImage()
 
 xml <- xmlExtraction(ometiff = image)
@@ -33,5 +34,5 @@ muBrainLW <- readLabWorksheet(muBrainLW, slideName = "4")
 overlay <- parseOverlayAttrs(omexml = xml, 
                              annots = muBrainLW, 
                              labworksheet = TRUE)
-
+}
 }

--- a/man/parseScanMetadata.Rd
+++ b/man/parseScanMetadata.Rd
@@ -17,11 +17,11 @@ metadata for entire scan
 Parse the xml file for the scan metadata of GeoMx images
 }
 \examples{
-
+\dontrun{
 image <- downloadMouseBrainImage()
 
 xml <- xmlExtraction(ometiff = image)
 
 scan_metadata <- parseScanMetadata(omexml = xml)
-
+}
 }

--- a/man/plotSpatialOverlay.Rd
+++ b/man/plotSpatialOverlay.Rd
@@ -71,11 +71,11 @@ overlay plots
 hiRes and outline ggplots use fill, lowRes uses color
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip",
                                     package = "SpatialOmicsOverlay")))
                              
 plotSpatialOverlay(overlay = muBrain, legend = FALSE,  
                    hiRes = FALSE, scaleBar = FALSE)
-
+}
 }

--- a/man/readLabWorksheet.Rd
+++ b/man/readLabWorksheet.Rd
@@ -18,9 +18,10 @@ df of ROI annotations
 Read lab worksheet into dataframe of annotations
 }
 \examples{
+\dontrun{
 muBrainLW <- system.file("extdata", "muBrain_LabWorksheet.txt", 
                          package = "SpatialOmicsOverlay")
 
 muBrainLW <- readLabWorksheet(muBrainLW, slideName = "4")
-
+}
 }

--- a/man/readSpatialOverlay.Rd
+++ b/man/readSpatialOverlay.Rd
@@ -46,7 +46,7 @@ Create an instance of class \code{\linkS4class{SpatialOverlay}}
 by reading data from OME-TIFF and annotation sheet.
 }
 \examples{
-
+\dontrun{
 muBrain_GxT <- readRDS(unzip(system.file("extdata", "muBrain_GxT.zip", 
                          package = "SpatialOmicsOverlay")))
 
@@ -55,7 +55,7 @@ image <- downloadMouseBrainImage()
 muBrain <- readSpatialOverlay(ometiff = image, annots = muBrain_GxT[,1:5], 
                               slideName = "4", image = TRUE, res = 8, 
                               saveFile = FALSE, outline = FALSE)
-
+}
 }
 \seealso{
 \code{\link{SpatialOverlay-class}}

--- a/man/recolor.Rd
+++ b/man/recolor.Rd
@@ -16,7 +16,7 @@ SpatialOverlay object with RGB image
 recolor images after changing colors and/or color intensities
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -28,5 +28,5 @@ muBrain <- add4ChannelImage(overlay = muBrain,
 muBrain <- changeImageColoring(overlay = muBrain, color = "magenta", 
                                dye = "Cy5")
 showImage(recolor(muBrain))
-
+}
 }

--- a/man/removeSample.Rd
+++ b/man/removeSample.Rd
@@ -18,7 +18,7 @@ SpatialOverlay object without samples in remove
 Remove sample(s) from SpatialOverlay
 }
 \examples{
-
+\dontrun{
 muBrain <- readRDS(unzip(system.file("extdata", "muBrainSubset_SpatialOverlay.zip", 
                                     package = "SpatialOmicsOverlay")))
 
@@ -33,5 +33,5 @@ muBrainSub <- removeSample(overlay = muBrain, remove = samps)
 
 muBrain
 muBrainSub
-
+}
 }

--- a/man/xmlExtraction.Rd
+++ b/man/xmlExtraction.Rd
@@ -21,8 +21,8 @@ list of xml data
 Extract xml from OME-TIFF
 }
 \examples{
-
+\dontrun{
 image <- downloadMouseBrainImage()
 xml <- xmlExtraction(ometiff = image)
-
+}
 }


### PR DESCRIPTION
CheckTime: 11 minutes 25.93 seconds
WARNING: R CMD check exceeded 10 min requirement

Setting examples to dontrun should cut down enough time to get under the 10 minute threshold

Instead of setting select examples to dontrun, I set them all 
![image](https://user-images.githubusercontent.com/40255151/217922971-92ba2e2b-d2fe-409d-b8f8-e101da99345f.png)
