### PR TITLE
add sf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Suggests:
     pheatmap,
     viridis,
     cowplot,
-    vdiffr
+    vdiffr,
+    sf
 License: MIT
 Collate: addImage.R
          addPlottingFactor.R


### PR DESCRIPTION
A customer sent a note to sDAS saying that there are dependencies that were removed from CRAN this month. `sp` is an SOO dependency at least 3 packages deep so nothing we can really do. SOO doesn't use the functions stated but I added the `sf` package as a Suggests just in case. 
![image](https://github.com/Nanostring-Biostats/SpatialOmicsOverlay/assets/40255151/78d23456-2db3-43ee-9d33-ac1672531cd5)
