### PR TITLE
Allow string names for ROIs

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -23,7 +23,7 @@ bookendStr <- function(x, bookend = 8){
     if(!is(x,"character")){
         x <- as.character(x)
     }
-    if(nchar(x) > bookend*2){
+    if(nchar(x)[1] > bookend*2){
         x <- paste(substr(x = x, start = 1, stop = bookend), "...",
                    substr(x = x, start = nchar(x)-(bookend-1), stop = nchar(x)),
                    paste0("(", nchar(x), " total char)"))
@@ -54,9 +54,9 @@ readLabWorksheet <- function(lw, slideName){
     
     startLine <- grep(readLines(lw), pattern = "^Annotations")
     
-    lw <- read.table(lw, header = TRUE, sep = "\t", skip = startLine, 
+    lw <- read.csv(lw, header = TRUE, sep = "\t", skip = startLine, 
                      fill = TRUE)
-    lw$ROILabel <- as.numeric(gsub("\"", "", gsub("=", "", lw$roi)))
+    lw$ROILabel <- lw$roi
     
     lw <- lw[lw$slide.name == slideName,]
     

--- a/R/xmlParsing.R
+++ b/R/xmlParsing.R
@@ -102,7 +102,7 @@ parseOverlayAttrs <- function(omexml, annots, labworksheet){
         ROInum <- ROIs[[ROI]]$AnnotationRef
         ROInum <- as.numeric(gsub("Annotation:", "", ROInum))
         
-        ROInum <- as.numeric(omexml$StructuredAnnotations[ROInum]$XMLAnnotation$Value$ChannelThresholds$RoiName)
+        ROInum <- omexml$StructuredAnnotations[ROInum]$XMLAnnotation$Value$ChannelThresholds$RoiName
         
         ROI <- ROIs[[ROI]]$Union
         
@@ -319,7 +319,7 @@ annotMatching <- function(annots, ROInum, maskNum, maskText){
         stop("The column ROILabel is not in annots. ")
     }
     
-    w2kp <- which(as.numeric(annots$ROILabel) == as.numeric(ROInum))
+    w2kp <- which(annots$ROILabel == ROInum)
     
     if(length(w2kp) == 0){
         return(NULL)


### PR DESCRIPTION
update readLabWorksheet to use read.csv because read.table does not read rois names column properly

includes index in bookendStr

remove as.numeric from annots and parseOverlayAttrs where it is not needed