### PR TITLE
Special character rois

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -56,7 +56,7 @@ readLabWorksheet <- function(lw, slideName){
     
     lw <- read.table(lw, header = TRUE, sep = "\t", skip = startLine, 
                      fill = TRUE)
-    lw$ROILabel <- gsub("\"", "", gsub("=", "", lw$roi))
+    lw$ROILabel <- gsub("\\W", "", lw$roi)
     
     lw <- lw[lw$slide.name == slideName,]
     

--- a/R/xmlParsing.R
+++ b/R/xmlParsing.R
@@ -103,6 +103,7 @@ parseOverlayAttrs <- function(omexml, annots, labworksheet){
         ROInum <- as.numeric(gsub("Annotation:", "", ROInum))
         
         ROInum <- omexml$StructuredAnnotations[ROInum]$XMLAnnotation$Value$ChannelThresholds$RoiName
+        ROInum <- gsub("\\W", "", ROInum)
         
         ROI <- ROIs[[ROI]]$Union
         


### PR DESCRIPTION
A customer found this string ROI issue again and submitted a PR #54. We had already fixed this issue but her fix worked and mine didn't for her dataset. It was determined that her dataset had special characters in the ROI names and we didn't account for that. 

Confirmed our string ROI test dataset worked with fix. 

Confirmed tests ran as expected with this fix. 
```
══ Results ═══════════════════════════════════
Duration: 156.5 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 422 ]
```